### PR TITLE
Update release and test workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release
+name: Release
 
 on:
   push:
@@ -38,8 +38,23 @@ jobs:
         env:
           ADBLOCK: true
 
+      - name: Lint
+        run: yarn lint
+
       - name: Build
         run: yarn build
+
+      - name: Check the distributive TypeScript declarations
+        run: yarn check:dts
+
+      - name: Build test bundle
+        run: yarn build:test
+
+      - name: Test on BrowserStack
+        env:
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+        run: yarn test:browserstack
 
       - name: Publish if version has been updated
         uses: pascalgn/npm-publish-action@1.3.9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-20.04
     timeout-minutes: 5
-    environment: production
+    environment: main
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,10 @@ on:
       - '**.md'
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-20.04
     timeout-minutes: 5
+    environment: production
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,11 @@ name: Lint and test
 on:
   pull_request:
   push:
-    branches:
+    branches-ignore:
       - main
       - dev
+    paths-ignore:
+      - '**.md'
 
 jobs:
   build:
@@ -55,10 +57,3 @@ jobs:
 
       - name: Build test bundle
         run: yarn build:test
-
-      - name: Test on BrowserStack
-        if: ${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' }}
-        env:
-          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
-          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-        run: yarn test:browserstack


### PR DESCRIPTION
I disabled CI workflow for `main` and `dev` branches, but copied testing steps to `release` workflow.

Also `release` workflow now has production env.

This is not ideal solution, but for now I think is good enough.

I will make a separate PR later to improve CI/CD pipeline all together to not build/test multiple times, since it not only increases runtime but has multiple points of failure.