### PR TITLE
Disable rtt detector

### DIFF
--- a/src/detectors/index.ts
+++ b/src/detectors/index.ts
@@ -11,7 +11,6 @@ import { detectPluginsArray } from './plugins_array'
 import { detectPluginsLengthInconsistency } from './plugins_inconsistency'
 import { detectProcess } from './process'
 import { detectProductSub } from './product_sub'
-import { detectRTT } from './rtt'
 import { detectUserAgent } from './user_agent'
 import { detectWebDriver } from './webdriver'
 import { detectWebGL } from './webgl'
@@ -32,7 +31,6 @@ export const detectors = {
   detectPluginsArray,
   detectPluginsLengthInconsistency,
   detectProcess,
-  detectRTT,
   detectUserAgent,
   detectWebDriver,
   detectWebGL,


### PR DESCRIPTION
`navigator.rtt` is not a reliable standalone source of information. Because of multiple false positives and no other way to fix this, I decided to disable it until I found a better solution.

Ref #90 and #69