### PR TITLE
Fix false positives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fingerprintjs/botd",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "botd is a browser library for JavaScript bot detection",
   "keywords": [
     "bot",

--- a/src/detectors/eval_length.ts
+++ b/src/detectors/eval_length.ts
@@ -1,14 +1,15 @@
 import { arrayIncludes } from '../utils/ponyfills'
-import { BrowserKind, ComponentDict, DetectorResponse, State } from '../types'
-import { getBrowserKind } from '../utils/browser'
+import { BrowserEngineKind, BrowserKind, ComponentDict, DetectorResponse, State } from '../types'
+import { getBrowserEngineKind, getBrowserKind } from '../utils/browser'
 
 export function detectEvalLengthInconsistency({ evalLength }: ComponentDict): DetectorResponse {
   if (evalLength.state !== State.Success) return
   const length = evalLength.value
   const browser = getBrowserKind()
+  const browserEngine = getBrowserEngineKind()
   return (
-    (length === 37 && !arrayIncludes([BrowserKind.Firefox, BrowserKind.Safari], browser)) ||
+    (length === 37 && !arrayIncludes([BrowserEngineKind.Webkit, BrowserEngineKind.Gecko], browserEngine)) ||
     (length === 39 && !arrayIncludes([BrowserKind.IE], browser)) ||
-    (length === 33 && !arrayIncludes([BrowserKind.Chrome, BrowserKind.Opera, BrowserKind.WeChat], browser))
+    (length === 33 && !arrayIncludes([BrowserEngineKind.Chromium], browserEngine))
   )
 }

--- a/src/detectors/plugins_inconsistency.ts
+++ b/src/detectors/plugins_inconsistency.ts
@@ -1,14 +1,13 @@
-import { BotKind, BrowserEngineKind, BrowserKind, ComponentDict, DetectorResponse, State } from '../types'
-import { getBrowserEngineKind, getBrowserKind, isAndroid, isDesktopSafari } from '../utils/browser'
+import { BotKind, BrowserEngineKind, ComponentDict, DetectorResponse, State } from '../types'
+import { getBrowserEngineKind, isAndroid, isDesktopSafari } from '../utils/browser'
 
 export function detectPluginsLengthInconsistency({ pluginsLength }: ComponentDict): DetectorResponse {
   if (pluginsLength.state !== State.Success) return
-  const browserKind = getBrowserKind()
   const browserEngineKind = getBrowserEngineKind()
-  // Chromium based android browsers and mobile safari have 0 plugins length.
+  // Chromium based android browsers and mobile webkit based browsers have 0 plugins length.
   if (
     (browserEngineKind === BrowserEngineKind.Chromium && isAndroid()) ||
-    (browserKind === BrowserKind.Safari && !isDesktopSafari())
+    (browserEngineKind === BrowserEngineKind.Webkit && !isDesktopSafari())
   )
     return
   if (pluginsLength.value === 0) return BotKind.HeadlessChrome


### PR DESCRIPTION
Resolves #102 and #101.

- `eval length inconsistency` detector is now based on browser engine kind, not browser kind (derived from useragent)
- `plugins length inconsistency` ignores mobile webkit based browsers now