### PR TITLE
set job schedule to 18

### DIFF
--- a/.github/workflows/check_upcoming_browser_versions.yml
+++ b/.github/workflows/check_upcoming_browser_versions.yml
@@ -8,7 +8,7 @@ name: Check upcoming browser versions
 
 on:
   schedule:
-    - cron: '0 19 ? * MON-FRI'
+    - cron: '0 18 ? * MON-FRI'
 env:
   BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
   BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}


### PR DESCRIPTION
We have updated our Fingerprint agent job to use more browser sessions, which means it will run longer, therefore rendering your job unable to start due to paralellism settings, so we propose that we take the latest slot to accomodate our long run times