### PR TITLE
Fix false positives due to navitator plugins inconsistency

### DIFF
--- a/src/detectors/plugins_inconsistency.ts
+++ b/src/detectors/plugins_inconsistency.ts
@@ -1,16 +1,9 @@
-import { BotKind, BrowserEngineKind, BrowserKind, ComponentDict, DetectorResponse, State } from '../types'
-import { getBrowserEngineKind, getBrowserKind, isAndroid, isDesktopSafari } from '../utils/browser'
+import { BotKind, BrowserKind, ComponentDict, DetectorResponse, State } from '../types'
+import { getBrowserKind, isAndroid } from '../utils/browser'
 
 export function detectPluginsLengthInconsistency({ pluginsLength }: ComponentDict): DetectorResponse {
   if (pluginsLength.state !== State.Success) return
-  const browserEngineKind = getBrowserEngineKind()
   const browserKind = getBrowserKind()
-  // Chromium based android browsers and mobile webkit based browsers have 0 plugins length.
-  if (
-    (browserEngineKind === BrowserEngineKind.Chromium && isAndroid()) ||
-    (browserEngineKind === BrowserEngineKind.Webkit && !isDesktopSafari()) ||
-    browserKind === BrowserKind.WeChat
-  )
-    return
+  if (browserKind !== BrowserKind.Chrome || isAndroid()) return
   if (pluginsLength.value === 0) return BotKind.HeadlessChrome
 }


### PR DESCRIPTION
This pr introduces a workaround for `detectPluginsLengthInconsistency` detector by  making sure we run this detector only for desktop chrome. 

Fixes #130 