### PR TITLE
Ignore uknown browser engine kind in detectEvalLengthInconsistency

### DIFF
--- a/src/detectors/eval_length.ts
+++ b/src/detectors/eval_length.ts
@@ -7,6 +7,9 @@ export function detectEvalLengthInconsistency({ evalLength }: ComponentDict): De
   const length = evalLength.value
   const browser = getBrowserKind()
   const browserEngine = getBrowserEngineKind()
+  if (browserEngine == BrowserEngineKind.Unknown) {
+    return false
+  }
   return (
     (length === 37 && !arrayIncludes([BrowserEngineKind.Webkit, BrowserEngineKind.Gecko], browserEngine)) ||
     (length === 39 && !arrayIncludes([BrowserKind.IE], browser)) ||


### PR DESCRIPTION
https://github.com/fingerprintjs/BotD/issues/130#issuecomment-1712690463