### PR TITLE
Actualize the `isDesktopSafari` function

### DIFF
--- a/playground/index.ts
+++ b/playground/index.ts
@@ -5,7 +5,7 @@ import {
   getDocumentFocus,
   getMozAppearanceSupport,
   isAndroid,
-  isDesktopSafari,
+  isDesktopWebKit,
 } from '../src/utils/browser'
 import './style.css'
 
@@ -43,7 +43,7 @@ const runDetection = async (): Promise<DetectionResult> => {
       documentFocus: getDocumentFocus(),
       mozAppearanceSupport: getMozAppearanceSupport(),
       isAndroid: isAndroid(),
-      isDesktopSafari: isDesktopSafari(),
+      isDesktopWebKit: isDesktopWebKit(),
     }
 
     return {

--- a/src/utils/browser.ts
+++ b/src/utils/browser.ts
@@ -93,9 +93,12 @@ export function isAndroid(): boolean {
   )
 }
 
-// Source: https://github.com/fingerprintjs/fingerprintjs/blob/43a84516755440a89f3093a3b27a021d3d7351b6/src/utils/browser.ts#L100C1-L113C2
-export function isDesktopSafari(): boolean {
+// Source: https://github.com/fingerprintjs/fingerprintjs/blob/109f8ef802169df3fa1c5d1baa4b7bc0abbc1d91/src/utils/browser.ts#L102C1-L118C2
+export function isDesktopWebKit(): boolean {
+  // Checked in Safari and DuckDuckGo
+
   const w = window
+  const { HTMLElement, Document } = w
 
   return (
     countTruthy([
@@ -103,8 +106,8 @@ export function isDesktopSafari(): boolean {
       !('ongestureend' in w),
       !('TouchEvent' in w),
       !('orientation' in w),
-      'HTMLElement' in w && !('autocapitalize' in HTMLElement.prototype),
-      'Document' in w && 'pointerLockElement' in Document.prototype,
+      HTMLElement && !('autocapitalize' in HTMLElement.prototype),
+      Document && 'pointerLockElement' in Document.prototype,
     ]) >= 4
   )
 }


### PR DESCRIPTION
The function [was improved](https://github.com/fingerprintjs/fingerprintjs/pull/927/commits/7c8f06a6fecfca007e329057bd2d15fd8cf77666) to be suitable for Safari 17.

The function was renamed to `isDesktopWebKit` because it was tested in another desktop WebKit browser: [DuckDuckGo](https://duckduckgo.com/mac).