### PR TITLE
Return the `monitoring` option documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -53,6 +53,16 @@ A request includes the following information:
 -   The HTTP headers that the client sends, including the origin and the referrer of the page where the library runs
 -   The IP of the client
 
+You can turn off these requests by using the `monitoring` option:
+
+```diff
+const botdPromise = BotD.load({
++ monitoring: false
+})
+```
+
+💡 Scripts downloaded from our CDN (https://openfpcdn.io) have monitoring disabled by default.
+
 ### CommonJS syntax:
 
 ```js
@@ -67,7 +77,7 @@ load()
 
 ## API
 
-#### `BotD.load(): Promise<BotDetector>`
+#### `BotD.load({ monitoring?: boolean }): Promise<BotDetector>`
 
 Builds an instance of `BotDetector`. We recommend calling it as early as possible,
 ideally during application startup. It returns a promise which you can chain on to call `BotDetector` methods later.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,17 @@ import { BotdError, BotDetectorInterface, BotKind, BotDetectionResult } from './
 import { collect, detect } from './api'
 
 /**
+ * Options for BotD loading
+ */
+export interface LoadOptions {
+  /**
+   * Set `false` to disable the unpersonalized AJAX request that the agent sends to collect installation statistics.
+   * It's always disabled in the version published to the FingerprintJS CDN.
+   */
+  monitoring?: boolean
+}
+
+/**
  * Sends an unpersonalized AJAX request to collect installation statistics
  */
 function monitor() {
@@ -24,8 +35,8 @@ function monitor() {
   }
 }
 
-export async function load(options?: Record<keyof any, any>): Promise<BotDetectorInterface> {
-  if (options?.monitoring ?? true) {
+export async function load({ monitoring = true }: Readonly<LoadOptions> = {}): Promise<BotDetectorInterface> {
+  if (monitoring) {
     monitor()
   }
   const detector = new BotDetector()


### PR DESCRIPTION
It has been decided to return the option to BotD, because it's licensed under MIT. This PR improves the package typing.

It reverses https://github.com/fingerprintjs/BotD/pull/146.