### PR TITLE
Allowing playground to be run on a nominated interface and port

### DIFF
--- a/playground/webpack.config.ts
+++ b/playground/webpack.config.ts
@@ -5,6 +5,8 @@ import { Configuration } from 'webpack'
 import 'webpack-dev-server'
 
 const isDev = process.env.DEV === '1'
+const port = process.env.BOTD_PORT || 3000
+const host = process.env.BOTD_HOST;
 
 const config: Configuration = {
   mode: isDev ? 'development' : 'production',
@@ -52,7 +54,8 @@ const config: Configuration = {
 
   devServer: {
     compress: !isDev,
-    port: 3000,
+    host: host,
+    port: port,
   },
 
   performance: {


### PR DESCRIPTION
Trying to allow playground to run when another process is listening on TCP/3000