### PR TITLE
Handle cases where `window.process` is not an object

### DIFF
--- a/src/sources/process.ts
+++ b/src/sources/process.ts
@@ -8,8 +8,13 @@ export interface ProcessPayload {
 }
 
 export default function getProcess(): ProcessPayload {
-  if (window.process === undefined) {
-    throw new BotdError(State.Undefined, 'window.process is undefined')
+  const { process } = window
+  const errorPrefix = 'window.process is'
+  if (process === undefined) {
+    throw new BotdError(State.Undefined, `${errorPrefix} undefined`)
   }
-  return <ProcessPayload>window.process
+  if (process && typeof process !== 'object') {
+    throw new BotdError(State.UnexpectedBehaviour, `${errorPrefix} not an object`)
+  }
+  return <ProcessPayload>process
 }


### PR DESCRIPTION
`window.process` is a function on [some websites](https://bloxflip.com). This causes an unexpected behavior in Pro Agent.

Once you merge the PR, please publish a new version of BotD.