### PR TITLE
Add Safari 18 to the list of tested browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "check:ssr": "node --require ./dist/botd.cjs.js --eval '' || (echo \"The distributive files can't be used with server side rendering. Make sure the code doesn't use browser API until an exported function is called.\" && exit 1)"
   },
   "devDependencies": {
-    "@fpjs-incubator/broyster": "^0.2.0",
+    "@fpjs-incubator/broyster": "^0.2.1",
     "@rollup/plugin-json": "^5.0.1",
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^10.0.1",

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,4 +1,4 @@
-import * as BotDModule from '../src'
+import type * as BotDModule from '../src'
 
 /*
  * Checks that the distributive file works in a browser.

--- a/yarn.lock
+++ b/yarn.lock
@@ -314,10 +314,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fpjs-incubator/broyster@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@fpjs-incubator/broyster/-/broyster-0.2.0.tgz#b2f5a190732279dee12039f6746e56d7b8236a72"
-  integrity sha512-26peB8A9XNZ28n61GW4Veq77eJtwQO79iXgamLXGzzbscf8XzV8tqBsO0SeU7I0nN6JN3QXBY6jsRVEZ0Y7crA==
+"@fpjs-incubator/broyster@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@fpjs-incubator/broyster/-/broyster-0.2.1.tgz#05fb1052da23e53aebedd9f62b4ecab61e27ff4c"
+  integrity sha512-GmE8/6wrACogDszd8Z5y52z/rGRPvhKvYTmuVFmmIe7udSELpRC+F1qliBD4Oa/lJUY4GKqiDKOSjc91hxLntA==
   dependencies:
     "@types/karma" "^6.3.3"
     async-lock "^1.4.0"


### PR DESCRIPTION
I didn't check BotD signals in Safari 18. They look normal from the Fingerprint Pro perspective, but please check by yourself.