### PR TITLE
do not rely on 0 plugins for detecting headlesschrome

### DIFF
--- a/src/detectors/plugins_inconsistency.ts
+++ b/src/detectors/plugins_inconsistency.ts
@@ -19,5 +19,4 @@ export function detectPluginsLengthInconsistency({
     browserEngineKind.value !== BrowserEngineKind.Chromium
   )
     return
-  if (pluginsLength.value === 0) return BotKind.HeadlessChrome
 }


### PR DESCRIPTION
Hello,

I'm running BotD in production and with one of my user I diagnosed that `navigator.plugins.length` returns `0` on his browser.

He is running Vivaldi 7.0.3495.18 (Stable channel) on Windows and without any extension installed the browser gives no plugins in the list:

![image](https://github.com/user-attachments/assets/1ca55b43-4016-4318-8542-6496b4dd41c1)

I'm proposing to remove the classification that if the plugins list is empty, then it's a headless chrome.

First because now for `--headless=new`, the value for `navigator.plugins.length` is not empty anymore. It's `5`. Everyone is already using that new headless method or spoofing the value for `navigator.plugins`

And second, the API `navigator.plugins` is no longer recommended: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/plugins. So we may run into some false positive if some browser decides to not disclose the plugins list as part of protecting the privacy of the user.